### PR TITLE
Let submodules be installed recursively in specified container directory

### DIFF
--- a/bin/pmbp.pl
+++ b/bin/pmbp.pl
@@ -1155,7 +1155,7 @@ sub add_git_submodule ($$;%) {
       info 5, "$git_dir_name: submodule <$url> is already added as |$submodule->{dir_name}|";
       if ($args{recursive} and $args{top_level}) {
         for my $submodule (grep { $_->{dir_name} =~ m{^modules/} } @{git_submodules "$git_dir_name/$submodule->{dir_name}"}) {
-          add_git_submodule $git_dir_name, $submodule->{url}, recursive => $args{recursive};
+          add_git_submodule $git_dir_name, $submodule->{url}, recursive => $args{recursive}, parent_dir_name => $parent;
         }
       }
       return undef;
@@ -1202,7 +1202,7 @@ sub add_git_submodule ($$;%) {
   }
   if ($args{recursive}) {
     for my $submodule (grep { $_->{dir_name} =~ m{^modules/} } @{git_submodules "$git_dir_name/$parent/$dir_name"}) {
-      add_git_submodule $git_dir_name, $submodule->{url}, recursive => $args{recursive};
+      add_git_submodule $git_dir_name, $submodule->{url}, recursive => $args{recursive}, parent_dir_name => $parent;
     }
   }
   return "$parent/$dir_name";
@@ -6387,7 +6387,8 @@ application.  See the L</FILES> section.
 
 Add a Git submodule recursively.  That is, this command adds the
 specified Git repository, as well as submodules of the repository in
-the C<modules> directory.
+the specified container directory (if specified) or the C<modules>
+directory (if not specified).
 
 =back
 

--- a/t/pmbp-git/submodule-add-r-3-parent-dir.t
+++ b/t/pmbp-git/submodule-add-r-3-parent-dir.t
@@ -1,0 +1,28 @@
+#!/bin/sh
+echo "1..4"
+basedir=$(cd `dirname $0`/../.. && pwd)
+pmbp=$basedir/bin/pmbp.pl
+tempdir=`perl -MFile::Temp=tempdir -e 'print tempdir'`/testapp
+
+mkdir -p $tempdir/foo
+cd $tempdir/foo && git init
+
+mkdir -p $tempdir/git1
+cd $tempdir/git1 && git init && touch a && git add a && git commit -m new
+
+mkdir -p $tempdir/git2
+cd $tempdir/git2 && git init && touch b && git add b && git submodule add $tempdir/git1 modules/git1 && git commit -m new
+
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively "t_deps/modules $tempdir/git2" && echo "ok 1") || echo "not ok 1"
+(cat $tempdir/foo/t_deps/modules/git1/a && echo "ok 2") || echo "not ok 2"
+
+mkdir -p $tempdir/git3
+cd $tempdir/git3 && git init && touch c && git add c && git commit -m new
+
+cd $tempdir/git2 && git submodule add $tempdir/git3 modules/git3 && git commit -m new
+
+cd $tempdir/foo/t_deps/modules/git2 && git pull
+(perl $pmbp --root-dir-name $tempdir/foo --add-git-submodule-recursively "t_deps/modules $tempdir/git2" && echo "ok 3") || echo "not ok 3"
+(cat $tempdir/foo/t_deps/modules/git3/c && echo "ok 4") || echo "not ok 4"
+
+rm -fr $tempdir


### PR DESCRIPTION
When executing `perl local/bin/pmbp.pl --add-git-submodule-recursively "<container-dir> <git-url>"`,

* As-is : submodule \<git-url> is installed into \<container-dir>, and its submodules are installed into the **modules directory**.
* To-be : submodule \<git-url> and its submodules are installed into \<container-dir>.
